### PR TITLE
fix(provider): support all commands for getSignedUrl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "loopback4-s3",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "loopback4-s3",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.58.0",
         "@aws-sdk/s3-request-presigner": "^3.58.0",
+        "@aws-sdk/smithy-client": "^3.99.0",
+        "@aws-sdk/types": "^3.78.0",
         "@loopback/boot": "^5.0.0",
         "@loopback/context": "^5.0.0",
         "@loopback/core": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.58.0",
     "@aws-sdk/s3-request-presigner": "^3.58.0",
+    "@aws-sdk/smithy-client": "^3.99.0",
+    "@aws-sdk/types": "^3.78.0",
     "@loopback/boot": "^5.0.0",
     "@loopback/context": "^5.0.0",
     "@loopback/core": "^4.0.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
-import {PutObjectCommand, S3} from '@aws-sdk/client-s3';
+import {S3, ServiceInputTypes} from '@aws-sdk/client-s3';
 import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
-import {RequestPresigningArguments} from '@aws-sdk/types';
+import {Command} from '@aws-sdk/smithy-client';
+import {MetadataBearer, RequestPresigningArguments} from '@aws-sdk/types';
 import {BindingKey} from '@loopback/core';
 
 export namespace AWSS3Bindings {
@@ -15,7 +16,20 @@ export interface AwsS3Config {
 }
 
 export class S3WithSigner extends S3 {
-  getSignedUrl(command: PutObjectCommand, options: RequestPresigningArguments) {
+  getSignedUrl<
+    InputType extends ServiceInputTypes,
+    OutputType extends MetadataBearer = MetadataBearer,
+  >(
+    command: Command<
+      InputType,
+      OutputType,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      any,
+      ServiceInputTypes,
+      MetadataBearer
+    >,
+    options?: RequestPresigningArguments,
+  ): Promise<string> {
     return getSignedUrl(this, command, options);
   }
 }


### PR DESCRIPTION
BREAKING CHANGE:
Changed type of getSignedUrl method

GH-60

Issue #60 

## Description

Changed type of getSignedUrl method

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [X] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
